### PR TITLE
Convert arrow functions to function markup

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ const config = {
   mode: mode,
   entry: __dirname + "/src/index.ts",
   devtool: "source-map",
+  target: "es5",
   output: {
     path: __dirname + "/lib",
     filename: outputFile.toLowerCase(),


### PR DESCRIPTION
Without this, navigo will not run in IE11.